### PR TITLE
[PATRO23-348] Budget contains invalid dates.

### DIFF
--- a/src/modules/budget/application/Budget/CreatingBudget/CreateBudget.cs
+++ b/src/modules/budget/application/Budget/CreatingBudget/CreateBudget.cs
@@ -40,14 +40,30 @@ public class HandleCreateBudget : ICommandHandler<CreateBudget>
 	{
 		var id = new BudgetId(command.Id);
 		var userId = new UserId(command.UserId);
+
+		DateTime startDate;
+		DateTime endDate;
+
+		if (command.Period.StartDate.Date == command.Period.EndDate.Date)
+		{
+			 startDate = command.Period.StartDate.Date;
+			 endDate = startDate.AddDays(1).AddMilliseconds(-1);
+		}
+		else
+		{
+			startDate = command.Period.StartDate;
+			endDate = command.Period.EndDate;
+		}
+
 		var budget = BudgetAggregate.Create(
-			id,
-			command.Name,
-			userId,
-			command.Limit,
-			command.Period,
-			command.Description,
-			command.IconName);
+				id,
+				command.Name,
+				userId,
+				command.Limit,
+				new Period(startDate, endDate),
+				command.Description,
+				command.IconName);
+
 		await this.budgetRepository.Persist(budget);
 	}
 }

--- a/src/modules/budget/application/Budget/CreatingBudget/CreateBudget.cs
+++ b/src/modules/budget/application/Budget/CreatingBudget/CreateBudget.cs
@@ -1,3 +1,4 @@
+using FluentDateTime;
 using Intive.Patronage2023.Modules.Budget.Contracts.ValueObjects;
 using Intive.Patronage2023.Modules.Budget.Domain;
 using Intive.Patronage2023.Modules.User.Contracts.ValueObjects;
@@ -41,19 +42,8 @@ public class HandleCreateBudget : ICommandHandler<CreateBudget>
 		var id = new BudgetId(command.Id);
 		var userId = new UserId(command.UserId);
 
-		DateTime startDate;
-		DateTime endDate;
-
-		if (command.Period.StartDate.Date == command.Period.EndDate.Date)
-		{
-			 startDate = command.Period.StartDate.Date;
-			 endDate = startDate.AddDays(1).AddMilliseconds(-1);
-		}
-		else
-		{
-			startDate = command.Period.StartDate;
-			endDate = command.Period.EndDate;
-		}
+		var startDate = command.Period.StartDate.BeginningOfDay();
+		var endDate = command.Period.EndDate.EndOfDay();
 
 		var budget = BudgetAggregate.Create(
 				id,

--- a/src/modules/budget/application/Budget/GettingBudgetStatistics/BudgetStatistics.cs
+++ b/src/modules/budget/application/Budget/GettingBudgetStatistics/BudgetStatistics.cs
@@ -14,7 +14,7 @@ public class BudgetStatistics<T>
 	/// <summary>
 	/// Trend value.
 	/// </summary>
-	public decimal TrendValue { get; set; }
+	public decimal? TrendValue { get; set; }
 
 	/// <summary>
 	/// Period value.

--- a/src/modules/budget/application/Budget/GettingBudgetStatistics/GetBudgetStatistics.cs
+++ b/src/modules/budget/application/Budget/GettingBudgetStatistics/GetBudgetStatistics.cs
@@ -99,6 +99,15 @@ public class GetBudgetStatisticQueryHandler : IQueryHandler<GetBudgetStatistics,
 			}
 		}
 
+		if (!budgetTransactionValues[0].DatePoint.Date.Equals(query.StartDate.Date))
+		{
+			budgetTransactionValues.Insert(0, new BudgetAmount()
+			{
+				DatePoint = query.StartDate,
+				Value = budgetValueAtStartDate,
+			});
+		}
+
 		decimal totalBudgetValue = this.budgetDbContext.Transaction
 			.For(budgetId)
 			.NotCancelled()

--- a/src/modules/budget/application/Budget/GettingBudgetStatistics/GetBudgetStatistics.cs
+++ b/src/modules/budget/application/Budget/GettingBudgetStatistics/GetBudgetStatistics.cs
@@ -102,7 +102,7 @@ public class GetBudgetStatisticQueryHandler : IQueryHandler<GetBudgetStatistics,
 			.Within(query.StartDate, query.EndDate)
 			.Sum(x => x.Value);
 
-		decimal trendValue = budgetTransactionValues[0].Value > 0 ? (budgetTransactionValues.Last().Value - budgetValueAtStartDate) / budgetValueAtStartDate * 100 : 0;
+		decimal? trendValue = budgetTransactionValues[0].Value > 0 ? (budgetTransactionValues.Last().Value - budgetValueAtStartDate) / budgetValueAtStartDate * 100 : null;
 
 		var result = new BudgetStatistics<BudgetAmount> { Items = budgetTransactionValues, TotalBudgetValue = totalBudgetValue, PeriodValue = periodValue, TrendValue = trendValue };
 		return result;

--- a/src/modules/budget/application/Budget/GettingBudgetStatistics/GetBudgetStatistics.cs
+++ b/src/modules/budget/application/Budget/GettingBudgetStatistics/GetBudgetStatistics.cs
@@ -106,7 +106,7 @@ public class GetBudgetStatisticQueryHandler : IQueryHandler<GetBudgetStatistics,
 			.Within(query.StartDate, query.EndDate)
 			.Sum(x => x.Value);
 
-		decimal trendValue = budgetTransactionValues[0].Value > 0 ? (budgetTransactionValues.Last().Value - budgetValueAtStartDate) / budgetValueAtStartDate * 100 : 0;
+		decimal trendValue = budgetTransactionValues[1].Value > 0 ? (budgetTransactionValues.Last().Value - budgetTransactionValues[1].Value) / budgetTransactionValues[1].Value * 100 : 0;
 
 		var result = new BudgetStatistics<BudgetAmount> { Items = budgetTransactionValues, TotalBudgetValue = totalBudgetValue, PeriodValue = periodValue, TrendValue = trendValue };
 		return result;

--- a/src/modules/budget/application/Budget/GettingBudgetStatistics/GetBudgetStatistics.cs
+++ b/src/modules/budget/application/Budget/GettingBudgetStatistics/GetBudgetStatistics.cs
@@ -76,6 +76,11 @@ public class GetBudgetStatisticQueryHandler : IQueryHandler<GetBudgetStatistics,
 				})
 				.ToListAsync(cancellationToken: cancellationToken);
 
+		if (budgetTransactionValues.Count == 0)
+		{
+			return new BudgetStatistics<BudgetAmount> { Items = budgetTransactionValues, TotalBudgetValue = 0, PeriodValue = 0, TrendValue = 0 };
+		}
+
 		budgetTransactionValues.Insert(0, new BudgetAmount()
 		{
 			Value = budgetValueAtStartDate,

--- a/src/modules/budget/application/Intive.Patronage2023.Modules.Budget.Application.csproj
+++ b/src/modules/budget/application/Intive.Patronage2023.Modules.Budget.Application.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="FluentDateTime" Version="2.1.0" />
 	  <PackageReference Include="FluentValidation" Version="11.5.1" />
 	  <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />

--- a/tests/integration/Intive.Patronage2023.Modules.Example.Application.IntegrationTests/Budget/GettingBudgetsStatistics/GetBudgetStatisticsQueryHandlerTests.cs
+++ b/tests/integration/Intive.Patronage2023.Modules.Example.Application.IntegrationTests/Budget/GettingBudgetsStatistics/GetBudgetStatisticsQueryHandlerTests.cs
@@ -205,7 +205,7 @@ public class GetBudgetStatisticsQueryHandlerTests : AbstractIntegrationTests
 		// Act
 		var result = await this.instance.Handle(budgetStatisticsQuery, CancellationToken.None);
 
-		result.Items.First().Value.Should().Be(1);
+		result.Items.First().Value.Should().Be(3);
 		result.Items.Last().Value.Should().Be(45);
 	}
 
@@ -480,7 +480,6 @@ public class GetBudgetStatisticsQueryHandlerTests : AbstractIntegrationTests
 
 		result.Items.Should().BeEquivalentTo(new List<BudgetAmount>()
 		{
-			new BudgetAmount() { Value = 0 },
 			new BudgetAmount() { Value = 1 },
 			new BudgetAmount() { Value = 3 },
 			new BudgetAmount() { Value = 6 },

--- a/tests/integration/Intive.Patronage2023.Modules.Example.Application.IntegrationTests/Budget/GettingBudgetsStatistics/GetBudgetStatisticsQueryHandlerTests.cs
+++ b/tests/integration/Intive.Patronage2023.Modules.Example.Application.IntegrationTests/Budget/GettingBudgetsStatistics/GetBudgetStatisticsQueryHandlerTests.cs
@@ -205,7 +205,7 @@ public class GetBudgetStatisticsQueryHandlerTests : AbstractIntegrationTests
 		// Act
 		var result = await this.instance.Handle(budgetStatisticsQuery, CancellationToken.None);
 
-		result.Items.First().Value.Should().Be(3);
+		result.Items.First().Value.Should().Be(1);
 		result.Items.Last().Value.Should().Be(45);
 	}
 

--- a/tests/integration/Intive.Patronage2023.Modules.Example.Application.IntegrationTests/Budget/GettingBudgetsStatistics/GetBudgetStatisticsQueryHandlerTests.cs
+++ b/tests/integration/Intive.Patronage2023.Modules.Example.Application.IntegrationTests/Budget/GettingBudgetsStatistics/GetBudgetStatisticsQueryHandlerTests.cs
@@ -480,6 +480,7 @@ public class GetBudgetStatisticsQueryHandlerTests : AbstractIntegrationTests
 
 		result.Items.Should().BeEquivalentTo(new List<BudgetAmount>()
 		{
+			new BudgetAmount() { Value = 0 },
 			new BudgetAmount() { Value = 1 },
 			new BudgetAmount() { Value = 3 },
 			new BudgetAmount() { Value = 6 },


### PR DESCRIPTION
I had conversation today with Bartek Kędziora, that if they make " one day budget", it doesn't work, so i have changed that, also in patro23-299 i forget the case where  list of transaction is empty, so i added if statment, which checks that.
![image](https://github.com/intive/patronage2023-dotnet/assets/52294433/68c03312-4b64-46d0-b020-323c34c6801c)
![image](https://github.com/intive/patronage2023-dotnet/assets/52294433/814108f4-0738-4348-bdac-d6ab3d1d7e13)
