### PR TITLE
Feature/PATRO23-349 Export budget via mail

### DIFF
--- a/src/modules/budget/infrastructure/Domain/BudgetEmailSender.cs
+++ b/src/modules/budget/infrastructure/Domain/BudgetEmailSender.cs
@@ -3,7 +3,7 @@ using System.Net.Mail;
 namespace Intive.Patronage2023.Modules.Budget.Infrastructure.Domain;
 
 /// <summary>
-/// Class responsible for exporting budgets and sending them via email.
+/// Class  responsible for exporting budgets and sending them via email.
 /// </summary>
 public class BudgetEmailSender
 {

--- a/src/modules/budget/infrastructure/Domain/BudgetSenderEmail.cs
+++ b/src/modules/budget/infrastructure/Domain/BudgetSenderEmail.cs
@@ -1,0 +1,77 @@
+using System.Globalization;
+using CsvHelper;
+using Intive.Patronage2023.Modules.Budget.Domain;
+using Intive.Patronage2023.Modules.User.Domain;
+using Intive.Patronage2023.Shared.Abstractions;
+using Intive.Patronage2023.Shared.Infrastructure.Email;
+
+namespace Intive.Patronage2023.Modules.Budget.Infrastructure.Domain;
+
+/// <summary>
+/// Class responsible for exporting budgets and sending them via email.
+/// </summary>
+public class BudgetSenderEmail
+{
+	private readonly IBlobStorageService blobStorageService;
+	private readonly ICsvService<BudgetAggregate> csvService;
+	private readonly IEmailService emailService;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BudgetSenderEmail"/> class.
+	/// </summary>
+	/// <param name="blobStorageService">The blob storage service.</param>
+	/// <param name="csvService">The CSV service.</param>
+	/// <param name="emailService">The email service.</param>
+	public BudgetSenderEmail(IBlobStorageService blobStorageService, ICsvService<BudgetAggregate> csvService, IEmailService emailService)
+	{
+		this.blobStorageService = blobStorageService;
+		this.csvService = csvService;
+		this.emailService = emailService;
+	}
+
+	/// <summary>
+	/// Exports budgets to a CSV file, uploads it to blob storage, and sends it via email.
+	/// </summary>
+	/// <param name="budgets">The list of budgets to export.</param>
+	/// <param name="user">The user to send the email to.</param>
+	/// <returns>A task representing the asynchronous operation.</returns>
+	public async Task ExportAndSendBudgets(List<BudgetAggregate> budgets, AppUser user)
+	{
+		// Generate a unique file name for the CSV file
+		string fileName = this.csvService.GenerateFileNameWithCsvExtension();
+
+		// Create a memory stream to write the CSV data
+		using (var stream = new MemoryStream())
+		{
+			// Create a CsvWriter
+			using (var writer = new StreamWriter(stream, leaveOpen: true))
+			using (var csvWriter = new CsvWriter(writer, CultureInfo.InvariantCulture))
+			{
+				// Write the budgets records to the memory stream
+				this.csvService.WriteRecordsToMemoryStream(budgets, csvWriter);
+
+				// Flush the writer to ensure all data is written to the stream
+				csvWriter.Flush();
+				writer.Flush();
+
+				// Reset the stream position to the beginning
+				stream.Position = 0;
+
+				// Upload the CSV file to blob storage
+				await this.blobStorageService.UploadToBlobStorage(stream, fileName);
+			}
+		}
+
+		// Generate the email message
+		var emailMessage = new EmailMessage
+		{
+			Subject = "Exported budgets",
+			Body = $"Dear {user.FirstName} {user.LastName},\n\nThe attached file contains budgets as on {DateTime.UtcNow.ToShortDateString()}.\n\nBest regards,\nInbudget Team",
+			SendToAddresses = new List<EmailAddress> { new EmailAddress(user.FirstName, user.Email) },
+			Attachments = new List<EmailAttachment> { new EmailAttachment(fileName, Convert.ToBase64String(File.ReadAllBytes(fileName))) },
+		};
+
+		// Send the email
+		this.emailService.SendEmail(emailMessage);
+	}
+}

--- a/src/modules/budget/infrastructure/Intive.Patronage2023.Modules.Budget.Infrastructure.csproj
+++ b/src/modules/budget/infrastructure/Intive.Patronage2023.Modules.Budget.Infrastructure.csproj
@@ -22,6 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\user\domain\Intive.Patronage2023.Modules.User.Domain.csproj" />
       <ProjectReference Include="..\domain\Intive.Patronage2023.Modules.Budget.Domain.csproj" />
     </ItemGroup>
 

--- a/src/shared/infrastructure/Email/BudgetSenderEmail.cs
+++ b/src/shared/infrastructure/Email/BudgetSenderEmail.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intive.Patronage2023.Modules.Budget.Infrastructure.Domain;
+internal class BudgetSenderEmail
+{
+}

--- a/src/shared/infrastructure/Email/EmailAddress.cs
+++ b/src/shared/infrastructure/Email/EmailAddress.cs
@@ -1,7 +1,7 @@
 namespace Intive.Patronage2023.Shared.Infrastructure.Email;
 
 /// <summary>
-/// Email address details.
+/// Email  address details.
 /// </summary>
 /// <param name="Name">Email adress name to identify.</param>
 /// <param name="Address">Email address.</param>

--- a/src/shared/infrastructure/Email/EmailAttachment.cs
+++ b/src/shared/infrastructure/Email/EmailAttachment.cs
@@ -1,0 +1,6 @@
+namespace Intive.Patronage2023.Shared.Infrastructure.Email;
+
+/// <summary>
+/// Email attachment.
+/// </summary>
+public record EmailAttachment(string FileName, string Content);

--- a/src/shared/infrastructure/Email/EmailAttachment.cs
+++ b/src/shared/infrastructure/Email/EmailAttachment.cs
@@ -1,6 +1,6 @@
 namespace Intive.Patronage2023.Shared.Infrastructure.Email;
 
 /// <summary>
-/// Email attachment.
+/// Email  attachment.
 /// </summary>
 public record EmailAttachment(string FileName, string Content);

--- a/src/shared/infrastructure/Email/EmailMessage.cs
+++ b/src/shared/infrastructure/Email/EmailMessage.cs
@@ -24,4 +24,9 @@ public class EmailMessage
 	/// Email body.
 	/// </summary>
 	public string? Body { get; set; }
+
+	/// <summary>
+	/// Email attachments.
+	/// </summary>
+	public List<EmailAttachment>? Attachments { get; set; }
 }

--- a/src/shared/infrastructure/Email/EmailMessage.cs
+++ b/src/shared/infrastructure/Email/EmailMessage.cs
@@ -1,7 +1,7 @@
 namespace Intive.Patronage2023.Shared.Infrastructure.Email;
 
 /// <summary>
-/// Email message class.
+/// Email  message class.
 /// </summary>
 public class EmailMessage
 {


### PR DESCRIPTION
Enable users to send exported budgets to their email address by adding a button in the budgets list. When the user clicks the button, the exported budgets should be attached to an email in CSV file format. 